### PR TITLE
[Wave-18.U2] unit tests: storage + security + antivirus

### DIFF
--- a/tests/unit/security/conftest.py
+++ b/tests/unit/security/conftest.py
@@ -1,0 +1,52 @@
+"""Bootstrap для unit-тестов security / antivirus.
+
+Pre-existing блокеры, которые здесь обходятся:
+
+1. ``BaseSettingsWithLoader`` ищет ``config.yml`` через ``consts.ROOT_DIR``,
+   а ``ROOT_DIR`` указывает на ``src/``. Подменяем на корень репозитория.
+2. ``LoggerManager`` (singleton при импорте ``logging_service``) пытается
+   подключиться к Graylog. Через env ``LOG_HOST=""`` отключаем graylog handler.
+3. ``cert_store.py`` импортирует ``main_session_manager``, что тянет цепочку
+   до ``psycopg2`` (который опционален и обычно не установлен в dev). Чтобы
+   in-memory тесты ``MemoryCertBackend`` работали без БД, **до** импорта
+   ``cert_store`` подменяем ``src.infrastructure.database.session_manager``
+   и ``src.infrastructure.database.models.cert`` пустыми заглушками.
+
+Эти стабы безопасны для unit-тестов: ``MemoryCertBackend`` и ``CertStore``
+работают исключительно с in-process dict, ни одна из ORM-зависимостей не
+вызывается.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from pathlib import Path
+
+# (1) ROOT_DIR -> корень репозитория, чтобы config.yml нашёлся.
+from src.core.config.constants import consts
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if (_REPO_ROOT / "config.yml").exists():
+    consts.ROOT_DIR = _REPO_ROOT
+
+# (2) Отключаем graylog в LoggerManager до импорта settings.
+os.environ.setdefault("LOG_HOST", "")
+os.environ.setdefault("LOG_UDP_PORT", "1")
+
+# (3) Стабим цепочку database/session_manager до того, как cert_store
+#     попытается её импортировать. Заглушки имеют только те атрибуты,
+#     которые читаются на module-level.
+_session_mod_name = "src.infrastructure.database.session_manager"
+if _session_mod_name not in sys.modules:
+    _session_stub = types.ModuleType(_session_mod_name)
+    _session_stub.main_session_manager = None  # type: ignore[attr-defined]
+    sys.modules[_session_mod_name] = _session_stub
+
+_cert_model_mod_name = "src.infrastructure.database.models.cert"
+if _cert_model_mod_name not in sys.modules:
+    _cert_model_stub = types.ModuleType(_cert_model_mod_name)
+    _cert_model_stub.CertHistory = type("CertHistory", (), {})  # type: ignore[attr-defined]
+    _cert_model_stub.CertRecord = type("CertRecord", (), {})  # type: ignore[attr-defined]
+    sys.modules[_cert_model_mod_name] = _cert_model_stub

--- a/tests/unit/security/test_antivirus_backends.py
+++ b/tests/unit/security/test_antivirus_backends.py
@@ -1,0 +1,368 @@
+"""Unit-тесты антивирусных backend'ов.
+
+Покрывает:
+
+* :class:`HttpAntivirusBackend` — обёртку над external-AV-сервисом
+  (mock-сервис с методами ``ping`` / ``scan_bytes``);
+* :class:`ClamAVUnixBackend` и :class:`ClamAVTcpBackend` — INSTREAM
+  через ``asyncio.open_unix_connection`` / ``asyncio.open_connection``
+  c monkeypatch'ом stream-ридера/райтера;
+* parsing ClamAV-ответа: ``stream: OK`` / ``stream: <SIG> FOUND``;
+* fallback-сценарий ``ConnectionError`` при недоступном backend'е.
+
+Реальная сеть и реальный clamd не требуются.
+"""
+
+# ruff: noqa: S101  # assert — стандартная идиома pytest
+
+from __future__ import annotations
+
+import asyncio
+import struct
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.core.interfaces.antivirus import AntivirusScanResult
+from src.infrastructure.antivirus.backends.clamav_tcp import ClamAVTcpBackend
+from src.infrastructure.antivirus.backends.clamav_unix import (
+    ClamAVUnixBackend,
+    _parse_clamav_response,
+)
+from src.infrastructure.antivirus.backends.http import HttpAntivirusBackend
+
+# ── HttpAntivirusBackend ───────────────────────────────────────────────────
+
+
+class _FakeHttpService:
+    """Минимальный fake внешнего AV-сервиса с ``ping`` / ``scan_bytes``."""
+
+    def __init__(
+        self,
+        *,
+        ping_ok: bool = True,
+        verdict: dict[str, Any] | None = None,
+        raise_on_scan: Exception | None = None,
+    ) -> None:
+        self._ping_ok = ping_ok
+        self._verdict = verdict or {"clean": True}
+        self._raise = raise_on_scan
+        self.calls: list[bytes] = []
+
+    async def ping(self) -> bool:
+        return self._ping_ok
+
+    async def scan_bytes(self, payload: bytes) -> dict[str, Any]:
+        self.calls.append(payload)
+        if self._raise is not None:
+            raise self._raise
+        return self._verdict
+
+
+async def test_http_backend_clean_verdict() -> None:
+    """``scan_bytes`` маппит ``clean=True`` из ответа сервиса."""
+    service = _FakeHttpService(verdict={"clean": True})
+    backend = HttpAntivirusBackend(service)
+
+    result = await backend.scan_bytes(b"some bytes")
+
+    assert isinstance(result, AntivirusScanResult)
+    assert result.clean is True
+    assert result.signature is None
+    assert result.backend == "http"
+    assert result.latency_ms is not None and result.latency_ms >= 0
+    assert service.calls == [b"some bytes"]
+
+
+async def test_http_backend_threat_verdict_with_signature() -> None:
+    """``signature`` извлекается из ответа сервиса."""
+    service = _FakeHttpService(
+        verdict={"clean": False, "signature": "Eicar-Test"}
+    )
+    backend = HttpAntivirusBackend(service)
+
+    result = await backend.scan_bytes(b"X")
+    assert result.clean is False
+    assert result.signature == "Eicar-Test"
+
+
+async def test_http_backend_threat_verdict_via_threat_field() -> None:
+    """Если сервис вместо ``signature`` отдаёт ``threat`` — это валидно."""
+    service = _FakeHttpService(verdict={"clean": False, "threat": "Trojan.X"})
+    backend = HttpAntivirusBackend(service)
+
+    result = await backend.scan_bytes(b"X")
+    assert result.clean is False
+    assert result.signature == "Trojan.X"
+
+
+async def test_http_backend_is_available_uses_ping() -> None:
+    """``is_available`` отдаёт ``True``, если ``ping`` -> ``True``."""
+    backend = HttpAntivirusBackend(_FakeHttpService(ping_ok=True))
+    assert await backend.is_available() is True
+
+    backend2 = HttpAntivirusBackend(_FakeHttpService(ping_ok=False))
+    assert await backend2.is_available() is False
+
+
+async def test_http_backend_is_available_without_ping_returns_true() -> None:
+    """Если у сервиса нет ``ping`` — backend оптимистично доступен."""
+
+    class _NoPing:
+        async def scan_bytes(self, _: bytes) -> dict[str, Any]:
+            return {"clean": True}
+
+    backend = HttpAntivirusBackend(_NoPing())
+    assert await backend.is_available() is True
+
+
+async def test_http_backend_scan_raises_connection_error_on_failure() -> None:
+    """Любая ошибка сервиса при ``scan_bytes`` -> ``ConnectionError``."""
+    service = _FakeHttpService(raise_on_scan=RuntimeError("boom"))
+    backend = HttpAntivirusBackend(service)
+
+    with pytest.raises(ConnectionError):
+        await backend.scan_bytes(b"x")
+
+
+async def test_http_backend_without_scan_method_raises_runtime_error() -> None:
+    """Если сервис не реализует ни ``scan_bytes``, ни ``scan_payload`` -> RuntimeError."""
+
+    class _Empty:
+        async def ping(self) -> bool:
+            return True
+
+    backend = HttpAntivirusBackend(_Empty())
+    with pytest.raises(RuntimeError):
+        await backend.scan_bytes(b"x")
+
+
+# ── ClamAV response parser ─────────────────────────────────────────────────
+
+
+def test_parse_clamav_clean_response() -> None:
+    """``stream: OK`` -> clean-вердикт без сигнатуры."""
+    result = _parse_clamav_response(
+        b"stream: OK\0", backend="clamav_unix", latency_ms=1.0
+    )
+    assert result.clean is True
+    assert result.signature is None
+    assert result.backend == "clamav_unix"
+
+
+def test_parse_clamav_threat_response() -> None:
+    """``stream: <SIG> FOUND`` -> threat-вердикт с сигнатурой."""
+    result = _parse_clamav_response(
+        b"stream: Win.Test.EICAR_HDB-1 FOUND\0",
+        backend="clamav_tcp",
+        latency_ms=2.0,
+    )
+    assert result.clean is False
+    assert result.signature == "Win.Test.EICAR_HDB-1"
+    assert result.backend == "clamav_tcp"
+
+
+def test_parse_clamav_unexpected_response_raises() -> None:
+    """Неожиданный ответ ClamAV -> ``RuntimeError``."""
+    with pytest.raises(RuntimeError):
+        _parse_clamav_response(
+            b"weird payload", backend="clamav_unix", latency_ms=1.0
+        )
+
+
+# ── ClamAV unix/TCP scan_bytes via stream mocks ────────────────────────────
+
+
+class _FakeWriter:
+    """Имитирует ``asyncio.StreamWriter`` — собирает записанные байты."""
+
+    def __init__(self) -> None:
+        self.buffer = bytearray()
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.extend(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class _FakeReader:
+    """Имитирует ``asyncio.StreamReader`` с заданным ответом."""
+
+    def __init__(self, response: bytes) -> None:
+        self._response = response
+
+    async def read(self, _n: int) -> bytes:
+        return self._response
+
+
+@pytest.fixture
+def fake_streams() -> tuple[_FakeReader, _FakeWriter]:
+    """Reader+Writer пара с дефолтным OK-ответом."""
+    return _FakeReader(b"stream: OK\0"), _FakeWriter()
+
+
+async def test_clamav_unix_scan_bytes_clean(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_streams: tuple[_FakeReader, _FakeWriter],
+    tmp_path: Any,
+) -> None:
+    """``scan_bytes`` поверх unix socket: OK-ответ -> clean."""
+    reader, writer = fake_streams
+
+    async def _open(_path: str) -> tuple[_FakeReader, _FakeWriter]:
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_unix_connection", _open)
+
+    backend = ClamAVUnixBackend(socket_path=str(tmp_path / "fake.sock"))
+    result = await backend.scan_bytes(b"abc")
+
+    assert result.clean is True
+    assert result.backend == "clamav_unix"
+    # Должны быть записаны: zINSTREAM\0 + (size_be32 + payload) + 0_be32 терминатор
+    assert writer.buffer.startswith(b"zINSTREAM\0")
+    assert writer.buffer.endswith(struct.pack(">I", 0))
+    assert writer.closed is True
+
+
+async def test_clamav_unix_scan_bytes_threat(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """``scan_bytes`` поверх unix socket: FOUND-ответ -> threat + signature."""
+    reader = _FakeReader(b"stream: Eicar-Signature FOUND\0")
+    writer = _FakeWriter()
+
+    async def _open(_path: str) -> tuple[_FakeReader, _FakeWriter]:
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_unix_connection", _open)
+
+    backend = ClamAVUnixBackend(socket_path=str(tmp_path / "fake.sock"))
+    result = await backend.scan_bytes(b"infected")
+
+    assert result.clean is False
+    assert result.signature == "Eicar-Signature"
+
+
+async def test_clamav_unix_scan_raises_connection_error_when_socket_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Any,
+) -> None:
+    """Если ``open_unix_connection`` падает — поднимается ``ConnectionError``."""
+
+    async def _fail(_path: str) -> tuple[_FakeReader, _FakeWriter]:
+        raise OSError("no socket")
+
+    monkeypatch.setattr(asyncio, "open_unix_connection", _fail)
+
+    backend = ClamAVUnixBackend(socket_path=str(tmp_path / "missing.sock"))
+    with pytest.raises(ConnectionError):
+        await backend.scan_bytes(b"x")
+
+
+async def test_clamav_unix_is_available_false_when_no_socket(
+    tmp_path: Any,
+) -> None:
+    """``is_available`` -> ``False``, если файла сокета нет."""
+    backend = ClamAVUnixBackend(socket_path=str(tmp_path / "no.sock"))
+    assert await backend.is_available() is False
+
+
+async def test_clamav_tcp_scan_bytes_clean(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``scan_bytes`` поверх TCP: OK-ответ -> clean."""
+    reader = _FakeReader(b"stream: OK\0")
+    writer = _FakeWriter()
+
+    async def _open(_host: str, _port: int) -> tuple[_FakeReader, _FakeWriter]:
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_connection", _open)
+
+    backend = ClamAVTcpBackend(host="127.0.0.1", port=3310)
+    result = await backend.scan_bytes(b"abc")
+    assert result.clean is True
+    assert result.backend == "clamav_tcp"
+
+
+async def test_clamav_tcp_is_available_pong(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``is_available`` -> ``True``, если ClamAV отвечает ``PONG``."""
+    reader = _FakeReader(b"PONG\0")
+    writer = _FakeWriter()
+
+    async def _open(_host: str, _port: int) -> tuple[_FakeReader, _FakeWriter]:
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_connection", _open)
+
+    backend = ClamAVTcpBackend(host="127.0.0.1", port=3310)
+    assert await backend.is_available() is True
+
+
+async def test_clamav_tcp_is_available_false_on_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``is_available`` -> ``False``, если open_connection падает."""
+
+    async def _fail(_host: str, _port: int) -> tuple[_FakeReader, _FakeWriter]:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(asyncio, "open_connection", _fail)
+
+    backend = ClamAVTcpBackend(host="127.0.0.1", port=3310)
+    assert await backend.is_available() is False
+
+
+async def test_clamav_tcp_scan_raises_connection_error_when_host_unreachable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Падение ``open_connection`` при ``scan_bytes`` -> ``ConnectionError``."""
+
+    async def _fail(_host: str, _port: int) -> tuple[_FakeReader, _FakeWriter]:
+        raise OSError("unreachable")
+
+    monkeypatch.setattr(asyncio, "open_connection", _fail)
+
+    backend = ClamAVTcpBackend(host="127.0.0.1", port=3310)
+    with pytest.raises(ConnectionError):
+        await backend.scan_bytes(b"x")
+
+
+# ── Optional respx integration (если установлен) ───────────────────────────
+
+
+def test_respx_is_optional() -> None:
+    """``respx`` не требуется для прохождения этого набора."""
+    respx = pytest.importorskip("respx", reason="respx не установлен — пропускаем")
+    # Если respx есть, проверим, что mock-transport фактически собирается.
+    assert hasattr(respx, "mock")
+
+
+# ── AsyncMock-based smoke ──────────────────────────────────────────────────
+
+
+async def test_http_backend_with_async_mock_service() -> None:
+    """``HttpAntivirusBackend`` корректно работает с ``AsyncMock``-сервисом."""
+    service = AsyncMock()
+    service.ping.return_value = True
+    service.scan_bytes.return_value = {"clean": True}
+
+    backend = HttpAntivirusBackend(service)
+    assert await backend.is_available() is True
+
+    result = await backend.scan_bytes(b"data")
+    assert result.clean is True
+    service.scan_bytes.assert_awaited_once_with(b"data")

--- a/tests/unit/security/test_antivirus_hash_cache.py
+++ b/tests/unit/security/test_antivirus_hash_cache.py
@@ -1,0 +1,197 @@
+"""Unit-тесты ``AntivirusHashCache``.
+
+Покрывает:
+
+* miss -> ``get`` возвращает ``None`` (Redis не знает ключа);
+* hit-clean -> ``put`` сохраняет clean-вердикт, ``get`` возвращает
+  ``AntivirusScanResult(clean=True, backend='cache')``;
+* hit-threat -> ``put`` сохраняет threat-вердикт с сигнатурой,
+  ``get`` отдаёт её;
+* кастомный ``ttl`` пробрасывается в ``Redis.set(ex=ttl)``;
+* поломка backend'а (``get``/``set`` raise) не ломает поток —
+  кэш ведёт себя как best-effort слой;
+* corrupt entry в Redis -> ``get`` возвращает ``None`` (graceful degrade);
+* сохранение однозначно по SHA-256: разные payload -> разные ключи.
+
+Backend выбирается так:
+* если установлен ``fakeredis`` -> используем ``FakeRedis(decode_responses=False)``;
+* иначе fallback на ``unittest.mock.AsyncMock``.
+"""
+
+# ruff: noqa: S101  # assert — стандартная идиома pytest
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+from unittest.mock import AsyncMock
+
+import orjson
+import pytest
+
+from src.core.interfaces.antivirus import AntivirusScanResult
+from src.infrastructure.antivirus.hash_cache import AntivirusHashCache
+
+# ── Fixtures ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fake_redis() -> Any:
+    """In-memory Redis-совместимый клиент.
+
+    Если ``fakeredis`` установлен — используется реальный fake.
+    Иначе — простейшая реализация на ``dict`` с поддержкой ``get``/``set``.
+    """
+    try:
+        import fakeredis.aioredis as far
+
+        return far.FakeRedis()
+    except ImportError:
+        return _DictRedis()
+
+
+class _DictRedis:
+    """Минимальный fake Redis с ``get``/``set`` и записью TTL."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, bytes] = {}
+        self.set_calls: list[tuple[str, bytes, int | None]] = []
+
+    async def get(self, key: str) -> bytes | None:
+        return self._data.get(key)
+
+    async def set(
+        self,
+        key: str,
+        value: bytes,
+        *,
+        ex: int | None = None,
+        **_: Any,
+    ) -> bool:
+        self._data[key] = value
+        self.set_calls.append((key, value, ex))
+        return True
+
+
+# ── Базовые сценарии ───────────────────────────────────────────────────────
+
+
+async def test_get_miss_returns_none(fake_redis: Any) -> None:
+    """Если Redis не знает ключа — ``get`` возвращает ``None``."""
+    cache = AntivirusHashCache(fake_redis)
+    assert await cache.get(b"unseen-payload") is None
+
+
+async def test_put_then_get_clean_verdict(fake_redis: Any) -> None:
+    """После ``put(clean=True)`` следующий ``get`` отдаёт clean-вердикт."""
+    cache = AntivirusHashCache(fake_redis)
+    payload = b"clean-bytes"
+    verdict = AntivirusScanResult(clean=True, backend="clamav_unix", latency_ms=5.0)
+
+    await cache.put(payload, verdict)
+
+    cached = await cache.get(payload)
+    assert cached is not None
+    assert cached.clean is True
+    assert cached.signature is None
+    assert cached.backend == "cache"
+    assert cached.latency_ms == 0.0
+
+
+async def test_put_then_get_threat_verdict(fake_redis: Any) -> None:
+    """После ``put(clean=False, signature=...)`` сигнатура сохраняется."""
+    cache = AntivirusHashCache(fake_redis)
+    payload = b"infected-bytes"
+    verdict = AntivirusScanResult(
+        clean=False, signature="Eicar-Test-Signature", backend="clamav_tcp"
+    )
+
+    await cache.put(payload, verdict)
+
+    cached = await cache.get(payload)
+    assert cached is not None
+    assert cached.clean is False
+    assert cached.signature == "Eicar-Test-Signature"
+    assert cached.backend == "cache"
+
+
+async def test_put_uses_default_ttl_when_not_specified() -> None:
+    """``put`` без ``ttl`` пробрасывает ``default_ttl`` в ``Redis.set(ex=...)``."""
+    client = _DictRedis()
+    cache = AntivirusHashCache(client, default_ttl=120)
+    await cache.put(b"x", AntivirusScanResult(clean=True))
+
+    assert client.set_calls
+    _, _, ex = client.set_calls[-1]
+    assert ex == 120
+
+
+async def test_put_custom_ttl_overrides_default() -> None:
+    """Явный ``ttl`` имеет приоритет над ``default_ttl``."""
+    client = _DictRedis()
+    cache = AntivirusHashCache(client, default_ttl=120)
+    await cache.put(b"x", AntivirusScanResult(clean=True), ttl=10)
+
+    _, _, ex = client.set_calls[-1]
+    assert ex == 10
+
+
+async def test_key_uses_sha256_prefix() -> None:
+    """Ключ имеет вид ``antivirus:hash:<sha256>``: разные payload -> разные ключи."""
+    client = _DictRedis()
+    cache = AntivirusHashCache(client)
+
+    await cache.put(b"a", AntivirusScanResult(clean=True))
+    await cache.put(b"b", AntivirusScanResult(clean=True))
+
+    expected_a = "antivirus:hash:" + hashlib.sha256(b"a").hexdigest()
+    expected_b = "antivirus:hash:" + hashlib.sha256(b"b").hexdigest()
+    keys = {key for key, _, _ in client.set_calls}
+    assert {expected_a, expected_b}.issubset(keys)
+
+
+# ── Resilience ─────────────────────────────────────────────────────────────
+
+
+async def test_get_returns_none_when_backend_raises() -> None:
+    """Падение ``Redis.get`` не должно эскалировать — ``get`` возвращает ``None``."""
+    client = AsyncMock()
+    client.get.side_effect = ConnectionError("redis down")
+
+    cache = AntivirusHashCache(client)
+    assert await cache.get(b"x") is None
+
+
+async def test_put_swallows_backend_error() -> None:
+    """Падение ``Redis.set`` не должно эскалировать — ``put`` тихий."""
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+
+    cache = AntivirusHashCache(client)
+    # Не должно бросать
+    await cache.put(b"x", AntivirusScanResult(clean=True))
+
+
+async def test_get_returns_none_on_corrupt_entry() -> None:
+    """Битые/несериализуемые байты в Redis -> ``get`` возвращает ``None``."""
+
+    class _BrokenRedis:
+        async def get(self, _key: str) -> bytes:
+            return b"not-a-valid-json{{{"
+
+    cache = AntivirusHashCache(_BrokenRedis())
+    assert await cache.get(b"any") is None
+
+
+async def test_get_uses_orjson_payload_layout(fake_redis: Any) -> None:
+    """Запись в Redis сериализуется через orjson и обратно читается полностью."""
+    cache = AntivirusHashCache(fake_redis)
+    verdict = AntivirusScanResult(clean=False, signature="Foo")
+    await cache.put(b"raw", verdict)
+
+    raw = await fake_redis.get(
+        "antivirus:hash:" + hashlib.sha256(b"raw").hexdigest()
+    )
+    assert raw is not None
+    decoded = orjson.loads(raw)
+    assert decoded == {"clean": False, "signature": "Foo"}

--- a/tests/unit/security/test_cert_store_memory.py
+++ b/tests/unit/security/test_cert_store_memory.py
@@ -1,0 +1,239 @@
+"""Unit-тесты ``MemoryCertBackend`` + ``CertStore`` (без БД).
+
+Покрывает:
+
+* ``MemoryCertBackend.save`` -> ``get`` round-trip;
+* версия инкрементируется при повторном ``save``;
+* ``history(service_id)`` возвращает все версии в порядке записи;
+* ``list_expiring(deadline)`` фильтрует по дате;
+* hot-cache фасад ``CertStore``: ``get`` использует кэш после ``set``;
+* ``invalidate(service_id)`` сбрасывает локальный кэш;
+* ``subscribe_updates`` -> подписчики получают ``service_id`` после ``set``.
+
+Все listener-варианты проверяются: sync-callable и async-coroutine.
+"""
+
+# ruff: noqa: S101  # assert — стандартная идиома pytest
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.core.config.cert_store import CertStoreSettings
+from src.infrastructure.security.cert_store import (
+    CertEntry,
+    CertStore,
+    MemoryCertBackend,
+)
+
+_TEST_PEM = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA\n"
+    "TEST-CERT-PAYLOAD-FOR-UNIT\n"
+    "-----END CERTIFICATE-----\n"
+)
+_TEST_PEM_V2 = _TEST_PEM.replace("TEST-CERT-PAYLOAD-FOR-UNIT", "ROTATED-PAYLOAD-V2")
+
+
+def _future(days: int = 365) -> datetime:
+    """Возвращает datetime ``days`` дней в будущем (UTC)."""
+    return datetime.now(tz=timezone.utc) + timedelta(days=days)
+
+
+def _settings() -> CertStoreSettings:
+    """``CertStoreSettings`` с in-memory backend для изолированных тестов."""
+    return CertStoreSettings(backend="memory")
+
+
+# ── MemoryCertBackend ──────────────────────────────────────────────────────
+
+
+async def test_memory_save_then_get_roundtrip() -> None:
+    """``save`` сохраняет запись, ``get`` возвращает её с теми же полями."""
+    backend = MemoryCertBackend()
+    expires = _future()
+
+    saved = await backend.save("svc1", _TEST_PEM, expires, description="primary")
+
+    assert isinstance(saved, CertEntry)
+    fetched = await backend.get("svc1")
+    assert fetched is not None
+    assert fetched.service_id == "svc1"
+    assert fetched.pem == _TEST_PEM
+    assert fetched.fingerprint == saved.fingerprint
+    assert fetched.expires_at == expires
+    assert fetched.description == "primary"
+    assert fetched.version == 1
+
+
+async def test_memory_get_missing_returns_none() -> None:
+    """``get`` несуществующего service_id возвращает ``None``."""
+    backend = MemoryCertBackend()
+    assert await backend.get("nope") is None
+
+
+async def test_memory_save_increments_version() -> None:
+    """Повторный ``save`` для того же ``service_id`` увеличивает ``version``."""
+    backend = MemoryCertBackend()
+    expires = _future()
+
+    first = await backend.save("svc1", _TEST_PEM, expires)
+    second = await backend.save("svc1", _TEST_PEM_V2, expires)
+
+    assert first.version == 1
+    assert second.version == 2
+    current = await backend.get("svc1")
+    assert current is not None
+    assert current.version == 2
+    assert current.pem == _TEST_PEM_V2
+
+
+async def test_memory_history_returns_all_versions() -> None:
+    """``history`` возвращает все версии для конкретного ``service_id``."""
+    backend = MemoryCertBackend()
+    expires = _future()
+
+    await backend.save("svc1", _TEST_PEM, expires)
+    await backend.save("svc1", _TEST_PEM_V2, expires)
+    await backend.save("svc2", _TEST_PEM, expires)
+
+    history = await backend.history("svc1")
+    assert [e.version for e in history] == [1, 2]
+    assert all(e.service_id == "svc1" for e in history)
+
+
+async def test_memory_list_expiring_filters_by_deadline() -> None:
+    """``list_expiring`` отдаёт только те записи, у которых ``expires_at <= deadline``."""
+    backend = MemoryCertBackend()
+
+    soon = _future(days=10)
+    far = _future(days=400)
+    await backend.save("soon", _TEST_PEM, soon)
+    await backend.save("far", _TEST_PEM_V2, far)
+
+    deadline = _future(days=30)
+    expiring = await backend.list_expiring(deadline)
+    ids = {e.service_id for e in expiring}
+    assert ids == {"soon"}
+
+
+# ── CertStore facade ───────────────────────────────────────────────────────
+
+
+async def test_certstore_set_then_get_uses_hot_cache() -> None:
+    """После ``set`` следующий ``get`` берёт значение из in-process cache."""
+    store = CertStore(MemoryCertBackend(), _settings())
+    expires = _future()
+
+    await store.set("svc1", _TEST_PEM, expires)
+    pem = await store.get("svc1")
+    assert pem == _TEST_PEM
+
+    # Подмена backend.get на падающий, чтобы убедиться, что cache hit
+    async def _boom(_service_id: str) -> None:
+        raise AssertionError("backend.get must not be called: cache hit expected")
+
+    store._backend.get = _boom
+    assert await store.get("svc1") == _TEST_PEM
+
+
+async def test_certstore_get_entry_returns_full_record() -> None:
+    """``get_entry`` возвращает ``CertEntry`` с метаданными."""
+    store = CertStore(MemoryCertBackend(), _settings())
+    expires = _future()
+    await store.set("svc1", _TEST_PEM, expires, description="desc")
+
+    entry = await store.get_entry("svc1")
+    assert entry is not None
+    assert entry.pem == _TEST_PEM
+    assert entry.expires_at == expires
+    assert entry.description == "desc"
+    assert entry.version == 1
+
+
+async def test_certstore_invalidate_drops_local_cache() -> None:
+    """``invalidate`` сбрасывает кэш — следующий ``get`` идёт в backend."""
+    backend = MemoryCertBackend()
+    store = CertStore(backend, _settings())
+    expires = _future()
+    await store.set("svc1", _TEST_PEM, expires)
+
+    calls = {"count": 0}
+    original_get = backend.get
+
+    async def _counting_get(service_id: str) -> CertEntry | None:
+        calls["count"] += 1
+        return await original_get(service_id)
+
+    backend.get = _counting_get
+
+    store.invalidate("svc1")
+    await store.get("svc1")
+    assert calls["count"] == 1
+
+
+async def test_certstore_subscribe_updates_sync_listener() -> None:
+    """Sync listener вызывается с ``service_id`` после ``set``."""
+    store = CertStore(MemoryCertBackend(), _settings())
+    received: list[str] = []
+    store.subscribe_updates(lambda sid: received.append(sid))
+
+    await store.set("svc1", _TEST_PEM, _future())
+
+    assert received == ["svc1"]
+
+
+async def test_certstore_subscribe_updates_async_listener() -> None:
+    """Async listener (coroutine) дожидается завершения после ``set``."""
+    store = CertStore(MemoryCertBackend(), _settings())
+    received: list[str] = []
+
+    async def _on_update(sid: str) -> None:
+        received.append(sid)
+
+    store.subscribe_updates(_on_update)
+    await store.set("svc1", _TEST_PEM, _future())
+
+    assert received == ["svc1"]
+
+
+async def test_certstore_listener_failure_is_swallowed() -> None:
+    """Падение одного listener'а не ломает остальных."""
+    store = CertStore(MemoryCertBackend(), _settings())
+    received: list[str] = []
+
+    def _bad(_sid: str) -> None:
+        raise RuntimeError("boom")
+
+    store.subscribe_updates(_bad)
+    store.subscribe_updates(lambda sid: received.append(sid))
+
+    await store.set("svc1", _TEST_PEM, _future())
+    assert received == ["svc1"]
+
+
+async def test_certstore_get_expiring_soon_uses_settings_window() -> None:
+    """``get_expiring_soon`` ограничен окном ``expire_warn_days`` из settings."""
+    backend = MemoryCertBackend()
+    settings = CertStoreSettings(backend="memory", expire_warn_days=7)
+    store = CertStore(backend, settings)
+
+    await store.set("close", _TEST_PEM, _future(days=3))
+    await store.set("far", _TEST_PEM_V2, _future(days=90))
+
+    expiring = await store.get_expiring_soon()
+    ids = {e.service_id for e in expiring}
+    assert ids == {"close"}
+
+
+async def test_certstore_from_settings_memory_backend_factory() -> None:
+    """``from_settings(backend='memory')`` собирает store с ``MemoryCertBackend``."""
+    settings = CertStoreSettings(backend="memory")
+    store = CertStore.from_settings(settings)
+    assert isinstance(store._backend, MemoryCertBackend)
+
+    pytest.importorskip("typing")  # просто чтобы тест не оставался "пустым"
+    await store.set("svc1", _TEST_PEM, _future())
+    assert await store.get("svc1") == _TEST_PEM

--- a/tests/unit/storage/conftest.py
+++ b/tests/unit/storage/conftest.py
@@ -1,0 +1,26 @@
+"""Bootstrap для unit-тестов storage.
+
+Решает pre-existing проблемы тестовой инфраструктуры:
+
+1. ``BaseSettingsWithLoader`` ищет ``config.yml`` через ``consts.ROOT_DIR``,
+   а ``ROOT_DIR`` указывает на ``src/``. Подменяем на корень репозитория.
+2. ``LoggerManager`` (singleton при импорте ``logging_service``) пытается
+   подключиться к Graylog через ``graypy``. Через env ``LOG_HOST=""``
+   отключаем graylog handler.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# (1) ROOT_DIR -> корень репозитория, чтобы config.yml нашёлся.
+from src.core.config.constants import consts
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+if (_REPO_ROOT / "config.yml").exists():
+    consts.ROOT_DIR = _REPO_ROOT
+
+# (2) Отключаем graylog в LoggerManager до импорта settings.
+os.environ.setdefault("LOG_HOST", "")
+os.environ.setdefault("LOG_UDP_PORT", "1")

--- a/tests/unit/storage/test_local_fs.py
+++ b/tests/unit/storage/test_local_fs.py
@@ -1,0 +1,120 @@
+"""Unit-тесты ``LocalFSStorage`` через ``tmp_path``.
+
+Покрывает:
+
+* round-trip ``upload`` -> ``download`` для байтов;
+* ``delete(key)`` после ``exists(key)=True`` -> ``exists(key)=False``;
+* ``list_keys(prefix)`` после нескольких uploads (поддержка вложенных
+  префиксов и сортировка результата);
+* ``presigned_url(key)`` возвращает корректный ``file://`` URI;
+* отсев path-traversal ключей (``..``/абсолютные пути) -> ``ValueError``.
+
+Тесты не используют сеть и реальный S3 — только локальная FS из
+``pytest tmp_path``.
+"""
+
+# ruff: noqa: S101  # assert — стандартная идиома pytest
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.infrastructure.storage.local_fs import LocalFSStorage
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> LocalFSStorage:
+    """Возвращает ``LocalFSStorage`` поверх изолированной ``tmp_path``."""
+    return LocalFSStorage(base_path=tmp_path)
+
+
+async def test_upload_download_roundtrip(storage: LocalFSStorage) -> None:
+    """``upload`` сохраняет байты, ``download`` возвращает их без изменений."""
+    payload = b"hello world\n"
+    await storage.upload("docs/note.txt", payload)
+    assert await storage.download("docs/note.txt") == payload
+
+
+async def test_upload_overwrites_existing(storage: LocalFSStorage) -> None:
+    """Повторный ``upload`` под тем же ключом перезаписывает данные атомарно."""
+    await storage.upload("a.bin", b"v1")
+    await storage.upload("a.bin", b"v2-longer")
+    assert await storage.download("a.bin") == b"v2-longer"
+
+
+async def test_delete_removes_existing_key(storage: LocalFSStorage) -> None:
+    """После ``delete`` файл больше не существует, ``exists`` возвращает False."""
+    await storage.upload("tmp/x.bin", b"data")
+    assert await storage.exists("tmp/x.bin") is True
+
+    await storage.delete("tmp/x.bin")
+    assert await storage.exists("tmp/x.bin") is False
+
+
+async def test_delete_missing_key_is_noop(storage: LocalFSStorage) -> None:
+    """``delete`` несуществующего ключа не падает (идемпотентно)."""
+    await storage.delete("never-was-here.bin")
+    assert await storage.exists("never-was-here.bin") is False
+
+
+async def test_list_keys_returns_relative_sorted_paths(
+    storage: LocalFSStorage,
+) -> None:
+    """После нескольких uploads ``list_keys`` возвращает относительные пути."""
+    await storage.upload("a.bin", b"1")
+    await storage.upload("dir/b.bin", b"2")
+    await storage.upload("dir/sub/c.bin", b"3")
+
+    keys = await storage.list_keys()
+    assert keys == ["a.bin", "dir/b.bin", "dir/sub/c.bin"]
+
+
+async def test_list_keys_with_prefix(storage: LocalFSStorage) -> None:
+    """``list_keys(prefix)`` фильтрует только записи внутри префикса."""
+    await storage.upload("a.bin", b"1")
+    await storage.upload("dir/b.bin", b"2")
+    await storage.upload("dir/sub/c.bin", b"3")
+
+    keys = await storage.list_keys("dir")
+    assert keys == ["dir/b.bin", "dir/sub/c.bin"]
+
+
+async def test_list_keys_missing_prefix_returns_empty(
+    storage: LocalFSStorage,
+) -> None:
+    """Несуществующий префикс возвращает пустой список без ошибки."""
+    assert await storage.list_keys("no-such-prefix") == []
+
+
+async def test_presigned_url_returns_file_uri(
+    storage: LocalFSStorage, tmp_path: Path
+) -> None:
+    """``presigned_url`` возвращает ``file://`` URI на абсолютный путь."""
+    await storage.upload("a.txt", b"x")
+    url = await storage.presigned_url("a.txt")
+    assert url.startswith("file://")
+    # URL должен указывать ровно на загруженный файл
+    expected = (tmp_path / "a.txt").resolve().as_uri()
+    assert url == expected
+
+
+async def test_unsafe_key_path_traversal_rejected(
+    storage: LocalFSStorage,
+) -> None:
+    """Ключ с ``..`` отвергается как path-traversal."""
+    with pytest.raises(ValueError):
+        await storage.upload("../escape.bin", b"x")
+
+
+async def test_unsafe_key_absolute_rejected(storage: LocalFSStorage) -> None:
+    """Абсолютный ключ (начинается с ``/``) отвергается."""
+    with pytest.raises(ValueError):
+        await storage.upload("/etc/passwd", b"x")
+
+
+async def test_unsafe_key_empty_rejected(storage: LocalFSStorage) -> None:
+    """Пустой ключ отвергается."""
+    with pytest.raises(ValueError):
+        await storage.exists("")


### PR DESCRIPTION
## Summary
- Unit tests: LocalFSStorage (tmp_path), CertStore + MemoryCertBackend, AntivirusHashCache, antivirus backends (HTTP/ClamAV)
- Локальные conftest.py с обходом pre-existing блокеров

## Recipe
- pytest collection ok, selective ok (skipped допустимо при отсутствии respx/fakeredis)
- ruff/mypy 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)